### PR TITLE
Fix incorrect route names

### DIFF
--- a/src/Form/MailExampleConfigEntityDeleteForm.php
+++ b/src/Form/MailExampleConfigEntityDeleteForm.php
@@ -29,7 +29,7 @@ class MailExampleConfigEntityDeleteForm extends EntityConfirmFormBase {
    *   A URL object.
    */
   public function getCancelUrl() {
-    return new Url('mail_example.entity.list');
+    return new Url('entity.mail_example.list');
   }
 
   /**
@@ -38,7 +38,7 @@ class MailExampleConfigEntityDeleteForm extends EntityConfirmFormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->entity->delete();
     drupal_set_message($this->t('Deleted @name', ['@name' => $this->entity->id()]));
-    $form_state->setRedirect('mail_example.entity.list');
+    $form_state->setRedirect('entity.mail_example.list');
   }
 
 }

--- a/src/Form/MailExampleConfigEntityForm.php
+++ b/src/Form/MailExampleConfigEntityForm.php
@@ -66,7 +66,7 @@ class MailExampleConfigEntityForm extends EntityForm {
       drupal_set_message($this->t('The @name config was NOT saved', ['@name' => $entity->id()]));
     }
     // Redirect the user back to list.
-    $form_state->setRedirect('mail_example.entity.list');
+    $form_state->setRedirect('entity.mail_example.list');
   }
 
 }


### PR DESCRIPTION
Exception thrown when trying to save a new entity due to incorrect route names that are fixed in this PR.

![screen shot 2017-02-01 at 14 17 30](https://cloud.githubusercontent.com/assets/339813/22510672/b78599c8-e88a-11e6-964b-ef805831c65e.png)
